### PR TITLE
D4G-72: Add Full WYSIWYG text editor.

### DIFF
--- a/config/default/editor.editor.full.yml
+++ b/config/default/editor.editor.full.yml
@@ -1,0 +1,61 @@
+uuid: 1b38916e-8606-4c93-a51c-a7b03ca1ac9f
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full
+  module:
+    - ckeditor5
+format: full
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - heading
+      - bold
+      - italic
+      - underline
+      - strikethrough
+      - blockQuote
+      - '|'
+      - alignment
+      - horizontalLine
+      - bulletedList
+      - numberedList
+      - indent
+      - outdent
+      - specialCharacters
+      - '|'
+      - link
+      - '|'
+      - drupalInsertImage
+      - sourceEditing
+  plugins:
+    ckeditor5_alignment:
+      enabled_alignments:
+        - center
+        - justify
+        - left
+        - right
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_imageResize:
+      allow_resize: true
+    ckeditor5_list:
+      reversed: true
+      startIndex: true
+    ckeditor5_sourceEditing:
+      allowed_tags: {  }
+image_upload:
+  status: true
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: 0
+    height: 0

--- a/config/default/filter.format.full.yml
+++ b/config/default/filter.format.full.yml
@@ -1,0 +1,17 @@
+uuid: f446c5f6-1efa-41ef-a03e-27f4b7daa991
+langcode: en
+status: true
+dependencies: {  }
+name: Full
+format: full
+weight: 0
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: ''
+      filter_html_help: true
+      filter_html_nofollow: false


### PR DESCRIPTION
## Description
> Per title

## Affected URL
admin/config/content/formats

## Related Tickets
https://drupal4gov.atlassian.net/browse/D4G-72

## Steps to Validate
1. Go to the above url and confirm that the text format field exists. 
2. Create content, confirm that the WYSIWYG is available on fields. 