### PR TITLE
D4G-173 config changes to events view 

### DIFF
--- a/config/default/views.view.webinar.yml
+++ b/config/default/views.view.webinar.yml
@@ -20,7 +20,7 @@ dependencies:
     - taxonomy
     - user
 id: webinar
-label: 'Events view'
+label: Events
 module: views
 description: ''
 tag: ''
@@ -33,7 +33,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Events
+      title: ''
       fields:
         title:
           id: title
@@ -198,7 +198,18 @@ display:
       cache:
         type: tag
         options: {  }
-      empty: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No events past or present'
+          tokenize: false
       sorts:
         field_date_value:
           id: field_date_value


### PR DESCRIPTION
Updated the 'Events view' to just say 'Events', removed title from each block, added unfiltered text under 'no result behavior'