### PR TITLE
D4G- 179 3rd tier nav

### DIFF
--- a/config/default/block.block.drupal4gov_main_menu.yml
+++ b/config/default/block.block.drupal4gov_main_menu.yml
@@ -22,6 +22,6 @@ settings:
   label_display: '0'
   provider: system
   level: 1
-  depth: 2
+  depth: 3
   expand_all_items: true
 visibility: {  }

--- a/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary-wide.css
+++ b/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary-wide.css
@@ -60,7 +60,7 @@
     align-items: center;
     width: -moz-max-content;
     width: max-content;
-    max-width: 200px;
+    max-width: 250px;
     margin: 0;
   }
   body:not(.is-always-mobile-nav) .primary-nav__menu-link--level-1:hover {
@@ -71,7 +71,7 @@
     top: calc(100% - 0.5 * var(--spacing));
     left: 50%;
     visibility: hidden;
-    width: 200px;
+    width: 250px;
     max-height: auto;
     margin-block: 0;
     margin-inline-start: -12px;
@@ -124,6 +124,16 @@
   }
   body:not(.is-always-mobile-nav) .primary-nav__menu-link--level-2:hover {
     text-decoration: underline;
+  }
+  body:not(.is-always-mobile-nav) .primary-nav__menu-link--level-3 {
+    display: block;
+    margin-block: var(--spacing);
+  }
+  body:not(.is-always-mobile-nav) .primary-nav__menu-link--level-3:hover {
+    text-decoration: underline;
+  }
+  body:not(.is-always-mobile-nav) .primary-nav__menu-link--level-3 .primary-nav__menu-link-inner {
+    padding: 0;
   }
 }
 

--- a/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary-wide.scss
+++ b/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary-wide.scss
@@ -76,7 +76,7 @@ body:not(.is-always-mobile-nav) {
       display: flex;
       align-items: center;
       width: max-content;
-      max-width: 200px;
+      max-width: 250px;
       margin: 0;
     }
 
@@ -91,7 +91,7 @@ body:not(.is-always-mobile-nav) {
       top: calc(100% - (0.5 * var(--spacing)));
       left: 50%;
       visibility: hidden;
-      width: 200px;
+      width: 250px;
       max-height: auto;
       margin-block: 0;
       margin-inline-start: -12px; // Visually center the dropdown on the text (not the button)
@@ -143,6 +143,19 @@ body:not(.is-always-mobile-nav) {
 
       &:hover {
         text-decoration: underline;
+      }
+    }
+
+    .primary-nav__menu-link--level-3 {
+      display: block;
+      margin-block: var(--spacing);
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      .primary-nav__menu-link-inner {
+        padding: 0;
       }
     }
   }

--- a/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary.css
+++ b/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary.css
@@ -131,7 +131,6 @@
 
 .primary-nav__menu-link--level-2 {
   font-size: var(--wide-font-size-submenu);
-  font-weight: normal;
   line-height: 1.5;
 }
 
@@ -139,4 +138,22 @@ html:not(.js) .primary-nav__menu--level-2 {
   visibility: visible;
   max-height: none;
   opacity: 1;
+}
+
+/*
+  Tertiary menu specific styles.
+*/
+.primary-nav__menu--level-3 {
+  padding-inline: 0;
+  margin-inline-start: calc(1.5 * var(--spacing));
+}
+
+.primary-nav__menu-item--level-3 {
+  margin-block: var(--spacing);
+}
+
+.primary-nav__menu-link--level-3 {
+  font-weight: normal;
+  font-size: var(--wide-font-size-submenu);
+  line-height: 1.5;
 }

--- a/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary.scss
+++ b/docroot/themes/custom/drupal4gov/components/primary-menu/css/nav-primary.scss
@@ -148,7 +148,6 @@
 
 .primary-nav__menu-link--level-2 {
   font-size: var(--wide-font-size-submenu);
-  font-weight: normal;
   line-height: 1.5;
 }
 
@@ -158,4 +157,22 @@ html:not(.js) {
     max-height: none;
     opacity: 1;
   }
+}
+
+/*
+  Tertiary menu specific styles.
+*/
+.primary-nav__menu--level-3 {
+  padding-inline: 0;
+  margin-inline-start: calc(1.5 * var(--spacing));
+}
+
+.primary-nav__menu-item--level-3 {
+  margin-block: var(--spacing);
+}
+
+.primary-nav__menu-link--level-3 {
+  font-weight: normal;
+  font-size: var(--wide-font-size-submenu);
+  line-height: 1.5;
 }


### PR DESCRIPTION
  - Make 2nd level bold (instead of 3rd)
  - Make sure 3rd-level items weren't larger than 2nd-level (as seen in "mobile" menu)
  - Make "desktop" flyouts a little wider to prevent unnecessary wrapping
  - Spacing adjustments (that I think work decently in both "mobile" and "desktop")