### PR TITLE
D4G-160: Add google_tag ...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal/entity_reference_revisions": "^1.11",
         "drupal/environment_indicator": "^4.0",
         "drupal/field_group": "^3.4",
+        "drupal/google_tag": "^2.0",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/manage_display": "^3.0",
         "drupal/minifyhtml": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b2b3c8d8404cb7864e9f40f7030e74e",
+    "content-hash": "84b85cc7bed370952c56d7f73fff5c0a",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -3561,6 +3561,78 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/field_group",
                 "issues": "https://www.drupal.org/project/issues/field_group"
+            }
+        },
+        {
+            "name": "drupal/google_tag",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/google_tag.git",
+                "reference": "2.0.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/google_tag-2.0.6.zip",
+                "reference": "2.0.6",
+                "shasum": "c8f2895a81a7898ac909bdc693fcd25ffe6f62be"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/commerce": "^2.0",
+                "drupal/commerce_wishlist": "^3.0@beta",
+                "drupal/csp": "^1.0",
+                "drupal/google_analytics": "^4.0",
+                "drupal/search_api": "^1.28.0",
+                "drupal/token": "^1.11.0",
+                "drupal/webform": "^6.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.6",
+                    "datestamp": "1721948116",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "acquia",
+                    "homepage": "https://www.drupal.org/user/1231722"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "kaynen",
+                    "homepage": "https://www.drupal.org/user/733308"
+                },
+                {
+                    "name": "mglaman",
+                    "homepage": "https://www.drupal.org/user/2416470"
+                },
+                {
+                    "name": "solotandem",
+                    "homepage": "https://www.drupal.org/user/240748"
+                }
+            ],
+            "description": "Provides support for Google Tag and Google Tag Manager in Drupal.",
+            "homepage": "https://www.drupal.org/project/google_tag",
+            "support": {
+                "source": "https://git.drupalcode.org/project/google_tag"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -30,6 +30,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  google_tag: 0
   image: 0
   inline_entity_form: 0
   inline_form_errors: 0

--- a/config/default/google_tag.container.G-Y57KEHNHVS.67195cb46fb631.78236052.yml
+++ b/config/default/google_tag.container.G-Y57KEHNHVS.67195cb46fb631.78236052.yml
@@ -1,0 +1,33 @@
+uuid: 0a31c0e0-bf90-402a-a178-aeca6009d038
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: G-Y57KEHNHVS.67195cb46fb631.78236052
+label: G-Y57KEHNHVS
+weight: 0
+tag_container_ids:
+  - G-Y57KEHNHVS
+advanced_settings:
+  consent_mode: false
+dimensions_metrics: {  }
+conditions:
+  user_role:
+    id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
+    roles:
+      anonymous: anonymous
+events:
+  generate_lead:
+    value: ''
+    currency: ''
+  search: {  }
+  webform_purchase: {  }
+  custom: {  }
+  login:
+    method: CMS
+  sign_up:
+    method: CMS

--- a/config/default/google_tag.settings.yml
+++ b/config/default/google_tag.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: cvh7di-mJogXOBiv_AoDN22DXIg3-OtzE5iLCIFAQ1s
+use_collection: false
+default_google_tag_entity: G-Y57KEHNHVS.67195cb46fb631.78236052


### PR DESCRIPTION
... using the property ID created with the web@drupal4gov.us account, configured to load only if anonymous (so excludes authenticated user hits).

And as [discussed here](https://drupal4govnp.slack.com/archives/C461MD3JL/p1729716931752289?thread_ts=1729716590.843859&cid=C461MD3JL), we'll skip config_split on this for time being.