### PR TITLE
D4G-216 board member image sizes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "drupal/environment_indicator": "^4.0",
         "drupal/field_group": "^3.4",
         "drupal/google_tag": "^2.0",
+        "drupal/image_effects": "^4.0",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/manage_display": "^3.0",
         "drupal/minifyhtml": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "408969ee78441038e93391b011afaad3",
+    "content-hash": "abe7e2ba0618f3571b60de2647f91af8",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -2200,6 +2200,51 @@
             "time": "2024-02-05T11:35:39+00:00"
         },
         {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
             "name": "drupal/acquia_connector",
             "version": "4.0.5",
             "source": {
@@ -3565,6 +3610,124 @@
             }
         },
         {
+            "name": "drupal/file_mdm",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/file_mdm.git",
+                "reference": "3.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/file_mdm-3.1.0.zip",
+                "reference": "3.1.0",
+                "shasum": "fa7709137705a693c4d5329035612473045a19d3"
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1",
+                "drupal/core": "^10.3 | ^11",
+                "fileeye/pel": "^0.10.0"
+            },
+            "require-dev": {
+                "drupal/vendor_stream_wrapper": "^2.0.4",
+                "fileeye/linuxlibertine-fonts": "^5.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.0",
+                    "datestamp": "1718086268",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a service to manage file metadata.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_exif",
+            "version": "3.1.0",
+            "require": {
+                "drupal/core": "^10.3 | ^11",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.0",
+                    "datestamp": "1718086268",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for EXIF image information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
+            "name": "drupal/file_mdm_font",
+            "version": "3.1.0",
+            "require": {
+                "drupal/core": "^10.3 | ^11",
+                "drupal/file_mdm": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "3.1.0",
+                    "datestamp": "1718086268",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                }
+            ],
+            "description": "Provides a file metadata plugin for TTF/OTF/WOFF font information.",
+            "homepage": "https://www.drupal.org/project/file_mdm",
+            "support": {
+                "source": "https://git.drupalcode.org/project/file_mdm"
+            }
+        },
+        {
             "name": "drupal/google_tag",
             "version": "2.0.6",
             "source": {
@@ -3634,6 +3797,74 @@
             "homepage": "https://www.drupal.org/project/google_tag",
             "support": {
                 "source": "https://git.drupalcode.org/project/google_tag"
+            }
+        },
+        {
+            "name": "drupal/image_effects",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/image_effects.git",
+                "reference": "4.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/image_effects-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "61a04f78275e907e8f06f74974660fef91e4a20c"
+            },
+            "require": {
+                "drupal/core": "^10.3.7 | ^11.0.6",
+                "drupal/file_mdm": "^3.1",
+                "drupal/file_mdm_exif": "*",
+                "drupal/file_mdm_font": "*"
+            },
+            "conflict": {
+                "drupal/color": "<2",
+                "drupal/imagemagick": "<4.0.1"
+            },
+            "require-dev": {
+                "drupal/color": "^2",
+                "drupal/imagemagick": "^4.0.2",
+                "drupal/token": "*",
+                "drupal/vendor_stream_wrapper": "^2.0.5",
+                "drush/drush": ">=12",
+                "fileeye/linuxlibertine-fonts": "^5.3"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.0",
+                    "datestamp": "1733831437",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "mondrake",
+                    "homepage": "https://www.drupal.org/user/1307444"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Provides effects and operations for the Image API.",
+            "homepage": "https://www.drupal.org/project/image_effects",
+            "support": {
+                "source": "https://git.drupalcode.org/project/image_effects"
             }
         },
         {
@@ -4996,6 +5227,69 @@
                 "source": "https://github.com/enlightn/security-checker/tree/v1.10.0"
             },
             "time": "2022-02-21T22:40:16+00:00"
+        },
+        {
+            "name": "fileeye/pel",
+            "version": "0.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FileEye/pel.git",
+                "reference": "5da1e6ab73508056f0abb79f560d20a315d1aefe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FileEye/pel/zipball/5da1e6ab73508056f0abb79f560d20a315d1aefe",
+                "reference": "5da1e6ab73508056f0abb79f560d20a315d1aefe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ext-exif": "*",
+                "ext-gd": "*",
+                "php-coveralls/php-coveralls": ">=2.7",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-phpunit": "^1.3.11",
+                "phpunit/phpunit": "^8 || ^9",
+                "squizlabs/php_codesniffer": ">=3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "lsolesen\\pel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Olesen",
+                    "email": "lars@intraface.dk",
+                    "homepage": "http://intraface.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Martin Geisler",
+                    "email": "martin@geisler.net",
+                    "homepage": "http://geisler.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Exif Library. A library for reading and writing Exif headers in JPEG and TIFF images using PHP.",
+            "homepage": "https://github.com/FileEye/pel",
+            "keywords": [
+                "exif",
+                "image"
+            ],
+            "support": {
+                "issues": "https://github.com/FileEye/pel/issues",
+                "source": "https://github.com/FileEye/pel/tree/0.10.0"
+            },
+            "time": "2024-01-11T19:11:58+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -12915,5 +13209,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/default/core.entity_view_display.node.board_member.teaser.yml
+++ b/config/default/core.entity_view_display.node.board_member.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.board_member.field_name
     - field.field.node.board_member.field_role
     - field.field.node.board_member.field_section
+    - image.style.board_member_teaser
     - node.type.board_member
   module:
     - image
@@ -24,7 +25,7 @@ content:
     label: hidden
     settings:
       image_link: ''
-      image_style: ''
+      image_style: board_member_teaser
       image_loading:
         attribute: lazy
     third_party_settings: {  }

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -29,9 +29,13 @@ module:
   field_group: 0
   field_ui: 0
   file: 0
+  file_mdm: 0
+  file_mdm_exif: 0
+  file_mdm_font: 0
   filter: 0
   google_tag: 0
   image: 0
+  image_effects: 0
   inline_entity_form: 0
   inline_form_errors: 0
   layout_builder: 0

--- a/config/default/file_mdm.file_metadata_plugin.getimagesize.yml
+++ b/config/default/file_mdm.file_metadata_plugin.getimagesize.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/default/file_mdm.settings.yml
+++ b/config/default/file_mdm.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: fOx6TBj_84WfX_a6JhuWiPQ-twAjHykvYsTvJAKbZsE
+metadata_cache:
+  enabled: true
+  expiration: 172800
+  disallowed_paths: {  }
+missing_file_log_level: 3

--- a/config/default/file_mdm_exif.file_metadata_plugin.exif.yml
+++ b/config/default/file_mdm_exif.file_metadata_plugin.exif.yml
@@ -1,0 +1,35 @@
+_core:
+  default_config_hash: u0ZqkNrnyVSnHXGBP0zlKY9dP1ZARzJZ9VSovzU_eDg
+ifd_map:
+  0:
+    type: 0
+    aliases:
+      - '0'
+      - IFD0
+      - Main
+  1:
+    type: 1
+    aliases:
+      - '1'
+      - IFD1
+      - Thumbnail
+  Exif:
+    type: 2
+    aliases:
+      - Exif
+  GPS:
+    type: 3
+    aliases:
+      - GPS
+  Interoperability:
+    type: 4
+    aliases:
+      - Interoperability
+      - Interop
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/default/file_mdm_font.file_metadata_plugin.font.yml
+++ b/config/default/file_mdm_font.file_metadata_plugin.font.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: o53U_2I-21Es-9iqxeUMDRcRxN0spL1OiHuAVQhh2oI
+configuration:
+  cache:
+    override: false
+    settings:
+      enabled: true
+      expiration: 172800
+      disallowed_paths: {  }

--- a/config/default/image.style.board_member_teaser.yml
+++ b/config/default/image.style.board_member_teaser.yml
@@ -1,0 +1,23 @@
+uuid: e6922fba-e1ca-445a-9148-1106a7c352da
+langcode: en
+status: true
+dependencies:
+  module:
+    - image_effects
+name: board_member_teaser
+label: 'Board member teaser (140x140)'
+effects:
+  35ed86e4-d58d-40aa-9009-f09c94545e0c:
+    uuid: 35ed86e4-d58d-40aa-9009-f09c94545e0c
+    id: image_scale_and_crop
+    weight: -9
+    data:
+      width: 140
+      height: 140
+      anchor: center-center
+  1fdb474a-840c-4972-85b9-191366733a62:
+    uuid: 1fdb474a-840c-4972-85b9-191366733a62
+    id: image_effects_auto_orient
+    weight: -10
+    data:
+      scan_exif: true

--- a/config/default/image_effects.settings.yml
+++ b/config/default/image_effects.settings.yml
@@ -1,0 +1,14 @@
+_core:
+  default_config_hash: eaXmaPSud65p-XhTwMIL9vKETD9zR3qNOMMa5EUuoNw
+color_selector:
+  plugin_id: html_color
+  plugin_settings:
+    html_color: {  }
+image_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }
+font_selector:
+  plugin_id: basic
+  plugin_settings:
+    basic: {  }


### PR DESCRIPTION
This should make the headshots at `/board-members` page (and anywhere else they might be displayed in "teaser" mode) render image files at a maximum of 140x140px (i.e. as large as the current CSS displays them, at any breakpoint).