### PR TITLE
D4G-211: Create button style for CKEditor

### DIFF
--- a/config/default/editor.editor.full.yml
+++ b/config/default/editor.editor.full.yml
@@ -12,6 +12,7 @@ settings:
   toolbar:
     items:
       - heading
+      - style
       - bold
       - italic
       - underline
@@ -53,6 +54,11 @@ settings:
       multiBlock: true
     ckeditor5_sourceEditing:
       allowed_tags: {  }
+    ckeditor5_style:
+      styles:
+        -
+          label: Button
+          element: '<a class="button button--primary">'
 image_upload:
   status: true
   scheme: public

--- a/config/default/filter.format.full.yml
+++ b/config/default/filter.format.full.yml
@@ -12,6 +12,6 @@ filters:
     status: false
     weight: -10
     settings:
-      allowed_html: ''
+      allowed_html: '<a class="button button--primary">'
       filter_html_help: true
       filter_html_nofollow: false

--- a/docroot/themes/custom/drupal4gov/css/base/forms.css
+++ b/docroot/themes/custom/drupal4gov/css/base/forms.css
@@ -280,6 +280,7 @@ select[multiple] option {
   cursor: pointer;
   font-size: 18px;
   font-weight: 600;
+  text-decoration: none;
 }
 .button:hover {
   background-color: #e5e5e5;
@@ -305,7 +306,6 @@ select[multiple] option {
   border: 3px solid var(--blue-bright);
   border-radius: 26px;
   color: white;
-  text-decoration: none;
   padding-block: 2rem;
 }
 .button.button--outline:hover {

--- a/docroot/themes/custom/drupal4gov/sass/base/forms.scss
+++ b/docroot/themes/custom/drupal4gov/sass/base/forms.scss
@@ -217,6 +217,7 @@ select {
   cursor: pointer;
   font-size: 18px;
   font-weight: 600;
+  text-decoration: none;
 
   &:hover {
     background-color: #e5e5e5;
@@ -247,7 +248,6 @@ select {
     border: 3px solid var(--blue-bright);
     border-radius: 26px;
     color: white;
-    text-decoration: none;
     padding-block: 2rem;
 
     &:hover {
@@ -297,7 +297,7 @@ select {
   }
 }
 
-.form-item-references { 
+.form-item-references {
   margin-top: 20px;
 
   label {


### PR DESCRIPTION
https://drupal4gov.atlassian.net/browse/D4G-211

- Enabled the Style widget on CKEditor Full-Text format
- Include a style option 'Button' to insert `.button` and `.button--primary` classes
- Updated `button` style class to remove the `text-decoration` underline for any button style instead of only `button--outline`