### PR TITLE
D4G-202: hardened headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "drupal/pathauto": "^1.13",
         "drupal/qa_accounts": "^1.0",
         "drupal/redirect": "^1.8",
+        "drupal/seckit": "^2.0",
         "drupal/shield": "^1.7",
         "drupal/simple_sitemap": "^4.2",
         "drupal/token": "^1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e6b086a7fbebcd65502d95a5f4c3b8c",
+    "content-hash": "9ea8f0001e27acdb779459dac2cbf2b6",
     "packages": [
         {
             "name": "acquia/acquia-cms-starterkit",
@@ -4958,6 +4958,67 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/seckit",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/seckit.git",
+                "reference": "2.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/seckit-2.0.3.zip",
+                "reference": "2.0.3",
+                "shasum": "34d38f2daaf99781ef6b7e7fbe2eeabc73a7ca16"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.3",
+                    "datestamp": "1726075930",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "badjava",
+                    "homepage": "https://www.drupal.org/user/83372"
+                },
+                {
+                    "name": "jweowu",
+                    "homepage": "https://www.drupal.org/user/152788"
+                },
+                {
+                    "name": "mcdruid",
+                    "homepage": "https://www.drupal.org/user/255969"
+                },
+                {
+                    "name": "p0deje",
+                    "homepage": "https://www.drupal.org/user/529960"
+                }
+            ],
+            "description": "SecKit provides Drupal with various security-hardening options.",
+            "homepage": "https://www.drupal.org/project/seckit",
+            "keywords": [
+                "Drupal",
+                "security"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/seckit",
+                "issues": "http://drupal.org/project/issues/seckit"
             }
         },
         {
@@ -13800,7 +13861,7 @@
     "platform": {
         "php": "8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -63,6 +63,7 @@ module:
   path: 0
   path_alias: 0
   sdc: 0
+  seckit: 0
   serialization: 0
   simple_sitemap: 0
   system: 0

--- a/config/default/seckit.settings.yml
+++ b/config/default/seckit.settings.yml
@@ -1,0 +1,52 @@
+_core:
+  default_config_hash: zzgpgFFYVnDh4Bu8k2ZNyNtoVeOOmmjTKvv41SWyRXo
+seckit_xss:
+  csp:
+    checkbox: false
+    vendor-prefix:
+      x: false
+      webkit: false
+    report-only: false
+    default-src: ''
+    script-src: ''
+    object-src: ''
+    style-src: ''
+    img-src: ''
+    media-src: ''
+    frame-src: ''
+    frame-ancestors: ''
+    child-src: ''
+    font-src: ''
+    connect-src: ''
+    report-uri: /report-csp-violation
+    upgrade-req: false
+    policy-uri: ''
+  x_xss:
+    select: 0
+seckit_csrf:
+  origin: false
+  origin_whitelist: ''
+seckit_clickjacking:
+  js_css_noscript: false
+  noscript_message: 'Sorry, you need to enable JavaScript to visit this website.'
+  x_frame: '1'
+  x_frame_allow_from: ''
+seckit_ssl:
+  hsts: false
+  hsts_subdomains: false
+  hsts_max_age: 1000
+  hsts_preload: false
+seckit_ct:
+  expect_ct: false
+  max_age: 86400
+  report_uri: ''
+  enforce: false
+seckit_fp:
+  feature_policy: false
+  feature_policy_policy: ''
+seckit_various:
+  from_origin: false
+  from_origin_destination: same
+  referrer_policy: false
+  referrer_policy_policy: no-referrer-when-downgrade
+  disable_autocomplete: false

--- a/config/default/seckit.settings.yml
+++ b/config/default/seckit.settings.yml
@@ -47,6 +47,6 @@ seckit_fp:
 seckit_various:
   from_origin: false
   from_origin_destination: same
-  referrer_policy: false
-  referrer_policy_policy: no-referrer-when-downgrade
+  referrer_policy: true
+  referrer_policy_policy: strict-origin-when-cross-origin
   disable_autocomplete: false

--- a/config/default/seckit.settings.yml
+++ b/config/default/seckit.settings.yml
@@ -32,9 +32,9 @@ seckit_clickjacking:
   x_frame: '1'
   x_frame_allow_from: ''
 seckit_ssl:
-  hsts: false
+  hsts: true
   hsts_subdomains: false
-  hsts_max_age: 1000
+  hsts_max_age: 300
   hsts_preload: false
 seckit_ct:
   expect_ct: false

--- a/config/default/system.performance.yml
+++ b/config/default/system.performance.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
-    max_age: 0
+    max_age: 86400
 css:
   preprocess: true
   gzip: true
@@ -14,4 +14,3 @@ fast_404:
 js:
   preprocess: true
   gzip: true
-stale_file_threshold: 2592000

--- a/config/envs/local/config_split.patch.system.performance.yml
+++ b/config/envs/local/config_split.patch.system.performance.yml
@@ -1,17 +1,10 @@
 adding:
-  cache:
-    page:
-      max_age: 86400
   css:
     preprocess: false
   js:
     preprocess: false
 removing:
-  cache:
-    page:
-      max_age: 0
   css:
     preprocess: true
   js:
     preprocess: true
-  stale_file_threshold: 2592000


### PR DESCRIPTION
A few changes to likely somewhat improve our score at the analysis found at https://dri.es/headers?url=https%3A%2F%2Fwww.drupal4gov.us (currently 4/10):

1. Change performance settings config so prod no longer exceptionally has no caching, as discussed in last week's meeting (should improve the analysis's warning and notice re: `cache-control`).
1. Add a relatively privacy-respecting `referrer-policy` header via SecKit module.
1. Enable the HTTP Strict Transport Security (HSTS) (`strict-transport-security` header) to require browsers to try to redirect any http load to the https version. Used a conservative 5 minute max-age based on [recommendations here](https://hstspreload.org/#deployment-recommendations), and didn't include subdomains, since I'm not sure what subdomains if any the domain has, besides `www`.
   * (Note: such redirection seems to already be handled by something else for prod, maybe Acquia. So this change may likely just improve the analysis score, as well as disable non-redirected http access on local.)

Skipped other missings/warnings/notices in report for either "don't want to inadvertently mess something up via Content-Security-Policy changes" reasons as well as "we wouldn't be in the worst company compared to other sites with vastly larger tech resources (e.g. WellsFargo, Reddit)" excuse.